### PR TITLE
Clean trash and caches in same layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,9 @@ RUN apt-get update && apt-get install -y \
   nodejs \
   openssl \
   rustc \
-  xz-utils
+  xz-utils \
+  && apt-get clean \
+  && apt-get autoremove -y
 
 # Create missing directory for git-daemon to work properly with runit
 RUN mkdir -p /var/lib/supervise/git-daemon
@@ -29,7 +31,8 @@ RUN gpg2 --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E206
   && curl -sSL https://get.rvm.io | bash -s stable
 
 RUN rvm install ruby-3.2.1 -C --with-jemalloc \
-  && rvm use --default ruby-3.2.1
+  && rvm use --default ruby-3.2.1 \
+  && rvm cleanup all
 
 # Set the required environment variables
 ENV RACK_ENV production


### PR DESCRIPTION
This is just a simple optimization which results in roughly ~35% final image size reduction.

Since docker is layer based technology then it's important to clean up stuff in the same layer. Otherwise, each layer will be bloated and even if they will be cleaned afterwards, it won't really affect docker image size.

This PR makes the image go from 2.23GB to 1.43GB which should affect continuous integration and continuous deployment speed.

BEFORE:
<img width="1485" alt="image" src="https://user-images.githubusercontent.com/5666244/222654623-05c19fc2-70c9-4e1e-859c-f1d4ba92003a.png">

AFTER: 

<img width="1482" alt="image" src="https://user-images.githubusercontent.com/5666244/222654104-3980468a-b110-483b-ac12-7f0f8a36c3cd.png">
