### PR TITLE
Bump ruby version to 3.3.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,18 +30,18 @@ RUN mkdir -p /var/lib/supervise/git-daemon
 RUN gpg2 --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB \
   && curl -sSL https://get.rvm.io | bash -s stable
 
-RUN rvm install ruby-3.3.1 -C --with-jemalloc \
-  && rvm use --default ruby-3.3.1 \
+RUN rvm install ruby-3.3.3 -C --with-jemalloc \
+  && rvm use --default ruby-3.3.3 \
   && rvm cleanup all
 
 # Set the required environment variables
 ENV RACK_ENV production
 ENV RAILS_ENV production
 ENV NODE_ENV production
-ENV PATH=${PATH}:/usr/local/rvm/rubies/ruby-3.3.1/bin
-ENV PATH=${PATH}:/usr/local/rvm/gems/ruby-3.3.1/bin
-ENV GEM_HOME /usr/local/rvm/gems/ruby-3.3.1
-ENV GEM_PATH /usr/local/rvm/gems/ruby-3.3.1
+ENV PATH=${PATH}:/usr/local/rvm/rubies/ruby-3.3.3/bin
+ENV PATH=${PATH}:/usr/local/rvm/gems/ruby-3.3.3/bin
+ENV GEM_HOME /usr/local/rvm/gems/ruby-3.3.3
+ENV GEM_PATH /usr/local/rvm/gems/ruby-3.3.3
 ENV LD_PRELOAD=${LD_PRELOAD}:/lib/x86_64-linux-gnu/libjemalloc.so.2
 ENV RUBY_YJIT_ENABLE 1
 


### PR DESCRIPTION
This updated ruby version to 3.3.3. News post on official ruby page: https://www.ruby-lang.org/en/news/2024/06/12/ruby-3-3-3-released/