### PR TITLE
Add libicu-dev to support icu for charlock_holmes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN echo -e "deb https://nginx.org/packages/ubuntu/ jammy nginx\ndeb-src https:/
 RUN apt-get update && apt-get install -y \
   git-all \
   gnupg2 \
+  libicu-dev \
   libjemalloc-dev \
   libpq-dev \
   nginx \


### PR DESCRIPTION
This adds `libicu-dev` to enable installing the `charlock_holmes` gem to enable us to detect encodings.